### PR TITLE
Removed prototype scope

### DIFF
--- a/client/src/main/java/nl/altindag/client/SSLConfig.java
+++ b/client/src/main/java/nl/altindag/client/SSLConfig.java
@@ -18,7 +18,6 @@ package nl.altindag.client;
 import nl.altindag.ssl.SSLFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 /**
@@ -39,7 +38,6 @@ import org.springframework.stereotype.Component;
 public class SSLConfig {
 
     @Bean
-    @Scope("prototype")
     public SSLFactory sslFactory(
             @Value("${client.ssl.one-way-authentication-enabled:false}") boolean oneWayAuthenticationEnabled,
             @Value("${client.ssl.two-way-authentication-enabled:false}") boolean twoWayAuthenticationEnabled,


### PR DESCRIPTION
The prototype scope was added 5 years ago in the following commit: https://github.com/Hakky54/mutual-tls-ssl/commit/ae75f5fdb5b6b3851538eef282988976145a85f8

At that stage the SSLFactory existed within this project in a different form. It was not a separate library and it was just a simple configuration class. The http requests failed for some reason and when using prototype every http client would get their own sslfactory instance. With the current version of sslfactory this should not be needed anymore.